### PR TITLE
Dispatch derail events based on speed

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -1696,8 +1696,17 @@ namespace Orts.Simulation.RollingStocks
                     // If derail climb time exceeded, then derail happens
                     if (DerailPossible && DerailElapsedTimeS > derailTimeS)
                     {
-                        DerailExpected = true;
-                        Simulator.Confirmer.Message(ConfirmLevel.Warning, Simulator.Catalog.GetStringFmt("Car {0} has derailed on the curve.", CarID));
+                        if (!DerailExpected)
+                        {
+                            DerailExpected = true;
+                            Simulator.Confirmer.Message(ConfirmLevel.Warning, Simulator.Catalog.GetStringFmt("Car {0} has derailed on the curve.", CarID));
+
+                            // Pick a derailment event based on speed for the sound system
+                            float speedMph = MpS.ToMpH(AbsSpeedMpS);
+                            Event derailEvent = speedMph < 10f ? Event.Derail1 :
+                                speedMph < 30f ? Event.Derail2 : Event.Derail3;
+                            SignalEvent(derailEvent);
+                        }
                       //  Trace.TraceInformation("Car Derail - CarID: {0}, Coupler: {1}, CouplerSmoothed {2}, Lateral {3}, Vertical {4}, Angle {5} Nadal {6} Coeff {7}", CarID, CouplerForceU, CouplerForceUSmoothed.SmoothedValue, TotalWagonLateralDerailForceN, TotalWagonVerticalDerailForceN, WagonCouplerAngleDerailRad, NadalDerailmentCoefficient, DerailmentCoefficient);
                      //   Trace.TraceInformation("Car Ahead Derail - CarID: {0}, Coupler: {1}, CouplerSmoothed {2}, Lateral {3}, Vertical {4}, Angle {5}", CarAhead.CarID, CarAhead.CouplerForceU, CarAhead.CouplerForceUSmoothed.SmoothedValue, CarAhead.TotalWagonLateralDerailForceN, CarAhead.TotalWagonVerticalDerailForceN, CarAhead.WagonCouplerAngleDerailRad);
                     }


### PR DESCRIPTION
## Summary
- trigger derailment sound events based on collision speed

## Testing
- `dotnet test Source/Tests/Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fc114cd88324a87e80dfad1c1435