### PR TITLE
Add basic derailed state handling for TrainCar

### DIFF
--- a/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/MSTSWagon.cs
@@ -1877,6 +1877,7 @@ namespace Orts.Simulation.RollingStocks
             outf.Write(DerailClimbDistanceM);
             outf.Write(DerailPossible);
             outf.Write(DerailExpected);
+            outf.Write(Derailed);
             outf.Write(DerailElapsedTimeS);
             for (int index = 0; index < 4; index++)
             {
@@ -1940,6 +1941,7 @@ namespace Orts.Simulation.RollingStocks
             DerailClimbDistanceM = inf.ReadSingle();
             DerailPossible = inf.ReadBoolean();
             DerailExpected = inf.ReadBoolean();
+            Derailed = inf.ReadBoolean();
             DerailElapsedTimeS = inf.ReadSingle();
             for (int index = 0; index < 4; index++)
             {

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -209,6 +209,8 @@ namespace Orts.Simulation.RollingStocks
         public bool DerailPossible = false;
         public bool DerailExpected = false;
         public float DerailElapsedTimeS;
+        public bool Derailed = false; // true once the car has left the track
+        public Vector3 DerailedVelocityMpS; // world-space velocity when derailed
 
         public float MaxHandbrakeForceN;
         public float MaxBrakeForceN = 89e3f;
@@ -832,6 +834,11 @@ namespace Orts.Simulation.RollingStocks
         // called when it's time to update the MotiveForce and FrictionForce
         public virtual void Update(float elapsedClockSeconds)
         {
+            if (Derailed)
+            {
+                UpdateDerailedPhysics(elapsedClockSeconds);
+                return;
+            }
 
             // Initialize RigidWheelBaseM in first loop if not defined in ENG file, then ignore
             if (RigidWheelBaseM == 0 && !RigidWheelBaseInitialised)   // Calculate default values if no value in Wag File
@@ -1698,6 +1705,7 @@ namespace Orts.Simulation.RollingStocks
                     {
                         DerailExpected = true;
                         Simulator.Confirmer.Message(ConfirmLevel.Warning, Simulator.Catalog.GetStringFmt("Car {0} has derailed on the curve.", CarID));
+                        TriggerDerailment();
                       //  Trace.TraceInformation("Car Derail - CarID: {0}, Coupler: {1}, CouplerSmoothed {2}, Lateral {3}, Vertical {4}, Angle {5} Nadal {6} Coeff {7}", CarID, CouplerForceU, CouplerForceUSmoothed.SmoothedValue, TotalWagonLateralDerailForceN, TotalWagonVerticalDerailForceN, WagonCouplerAngleDerailRad, NadalDerailmentCoefficient, DerailmentCoefficient);
                      //   Trace.TraceInformation("Car Ahead Derail - CarID: {0}, Coupler: {1}, CouplerSmoothed {2}, Lateral {3}, Vertical {4}, Angle {5}", CarAhead.CarID, CarAhead.CouplerForceU, CarAhead.CouplerForceUSmoothed.SmoothedValue, CarAhead.TotalWagonLateralDerailForceN, CarAhead.TotalWagonVerticalDerailForceN, CarAhead.WagonCouplerAngleDerailRad);
                     }
@@ -1745,6 +1753,30 @@ namespace Orts.Simulation.RollingStocks
                 }
             }
 
+        }
+
+        void TriggerDerailment()
+        {
+            if (Derailed)
+                return;
+            Derailed = true;
+            // capture current forward velocity as world vector
+            var forward = new Vector3(WorldPosition.XNAMatrix.M31, WorldPosition.XNAMatrix.M32, WorldPosition.XNAMatrix.M33);
+            DerailedVelocityMpS = forward * SpeedMpS;
+        }
+
+        void UpdateDerailedPhysics(float elapsedClockSeconds)
+        {
+            // apply gravity to world-space velocity
+            DerailedVelocityMpS += new Vector3(0, -GravitationalAccelerationMpS2 * elapsedClockSeconds, 0);
+            // update world position
+            WorldPosition.XNAMatrix.Translation += DerailedVelocityMpS * elapsedClockSeconds;
+            // update scalar speed along forward vector for coupler logic
+            var forward = new Vector3(WorldPosition.XNAMatrix.M31, WorldPosition.XNAMatrix.M32, WorldPosition.XNAMatrix.M33);
+            SpeedMpS = Vector3.Dot(DerailedVelocityMpS, forward);
+            AbsSpeedMpS = Math.Abs(SpeedMpS);
+            GravityForceN = MassKG * -GravitationalAccelerationMpS2;
+            CurrentElevationPercent = 0f;
         }
 
         #endregion
@@ -2799,6 +2831,11 @@ namespace Orts.Simulation.RollingStocks
 
         public void ComputePosition(Traveller traveler, bool backToFront, float elapsedTimeS, float distance, float speed)
         {
+            if (Derailed)
+            {
+                traveler.Move(CarLengthM);
+                return;
+            }
             for (var j = 0; j < Parts.Count; j++)
                 Parts[j].InitLineFit();
             var tileX = traveler.TileX;


### PR DESCRIPTION
## Summary
- Add `Derailed` state to `TrainCar` that activates when `DerailExpected` triggers
- Convert derailed cars to simple world-space rigid bodies and update their motion outside track physics
- Persist derailed state in wagon save/restore routines

## Testing
- `dotnet build Source/ORTS.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fc0f9d9c832495292aef0ab5406e