### PR TITLE
Add option to toggle visual derailment features

### DIFF
--- a/Source/Menu/Options.Designer.cs
+++ b/Source/Menu/Options.Designer.cs
@@ -208,6 +208,7 @@
             this.label9 = new System.Windows.Forms.Label();
             this.AdhesionFactorChangeValueLabel = new System.Windows.Forms.Label();
             this.AdhesionFactorValueLabel = new System.Windows.Forms.Label();
+            this.checkVisualDerailment = new System.Windows.Forms.CheckBox();
             this.checkShapeWarnings = new System.Windows.Forms.CheckBox();
             this.AdhesionLevelValue = new System.Windows.Forms.Label();
             this.AdhesionLevelLabel = new System.Windows.Forms.Label();
@@ -2409,6 +2410,7 @@
             this.tabPageExperimental.Controls.Add(this.label9);
             this.tabPageExperimental.Controls.Add(this.AdhesionFactorChangeValueLabel);
             this.tabPageExperimental.Controls.Add(this.AdhesionFactorValueLabel);
+            this.tabPageExperimental.Controls.Add(this.checkVisualDerailment);
             this.tabPageExperimental.Controls.Add(this.checkShapeWarnings);
             this.tabPageExperimental.Controls.Add(this.AdhesionLevelValue);
             this.tabPageExperimental.Controls.Add(this.AdhesionLevelLabel);
@@ -2617,9 +2619,19 @@
             this.AdhesionFactorValueLabel.Size = new System.Drawing.Size(292, 13);
             this.AdhesionFactorValueLabel.TabIndex = 27;
             this.AdhesionFactorValueLabel.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            // 
+            //
+            // checkVisualDerailment
+            //
+            this.checkVisualDerailment.AutoSize = true;
+            this.checkVisualDerailment.Location = new System.Drawing.Point(6, 212);
+            this.checkVisualDerailment.Name = "checkVisualDerailment";
+            this.checkVisualDerailment.Size = new System.Drawing.Size(112, 17);
+            this.checkVisualDerailment.TabIndex = 37;
+            this.checkVisualDerailment.Text = "Visual derailment";
+            this.checkVisualDerailment.UseVisualStyleBackColor = true;
+            //
             // checkShapeWarnings
-            // 
+            //
             this.checkShapeWarnings.AutoSize = true;
             this.checkShapeWarnings.Location = new System.Drawing.Point(6, 189);
             this.checkShapeWarnings.Name = "checkShapeWarnings";
@@ -3030,6 +3042,7 @@
         private System.Windows.Forms.Button buttonContentAdd;
         private System.Windows.Forms.Label labelContent;
         private System.Windows.Forms.CheckBox checkShapeWarnings;
+        private System.Windows.Forms.CheckBox checkVisualDerailment;
         private System.Windows.Forms.Label labelDayAmbientLight;
         private System.Windows.Forms.CheckBox checkEnableTCSScripts;
         private System.Windows.Forms.CheckBox checkCorrectQuestionableBrakingParams;

--- a/Source/Menu/Options.cs
+++ b/Source/Menu/Options.cs
@@ -337,6 +337,7 @@ namespace ORTS
             trackAdhesionFactorChange.Value = Settings.AdhesionFactorChange;
             trackAdhesionFactor_ValueChanged(null, null);
             checkShapeWarnings.Checked = !Settings.SuppressShapeWarnings;   // Inverted as "Show warnings" is better UI than "Suppress warnings"
+            checkVisualDerailment.Checked = Settings.VisualDerailment;
             checkCorrectQuestionableBrakingParams.Checked = Settings.CorrectQuestionableBrakingParams;
             numericActRandomizationLevel.Value = Settings.ActRandomizationLevel;
             numericActWeatherRandomizationLevel.Value = Settings.ActWeatherRandomizationLevel;
@@ -526,6 +527,7 @@ namespace ORTS
             Settings.AdhesionFactor = (int)trackAdhesionFactor.Value;
             Settings.AdhesionFactorChange = (int)trackAdhesionFactorChange.Value;
             Settings.SuppressShapeWarnings = !checkShapeWarnings.Checked;
+            Settings.VisualDerailment = checkVisualDerailment.Checked;
             Settings.CorrectQuestionableBrakingParams = checkCorrectQuestionableBrakingParams.Checked;
             Settings.ActRandomizationLevel = (int)numericActRandomizationLevel.Value;
             Settings.ActWeatherRandomizationLevel = (int)numericActWeatherRandomizationLevel.Value;

--- a/Source/ORTS.Settings/UserSettings.cs
+++ b/Source/ORTS.Settings/UserSettings.cs
@@ -329,6 +329,8 @@ namespace ORTS.Settings
         public bool CorrectQuestionableBrakingParams { get; set; }
         [Default(false)]
         public bool OpenDoorsInAITrains { get; set; }
+        [Default(false)]
+        public bool VisualDerailment { get; set; }
         [Default(0)]
         public int ActRandomizationLevel { get; set; }
         [Default(0)]

--- a/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
+++ b/Source/Orts.Simulation/Simulation/RollingStocks/TrainCar.cs
@@ -1271,6 +1271,16 @@ namespace Orts.Simulation.RollingStocks
 
         public void UpdateTrainDerailmentRisk(float elapsedClockSeconds)
         {
+            if (!Simulator.Settings.VisualDerailment)
+            {
+                TotalWagonLateralDerailForceN = 0;
+                TotalWagonVerticalDerailForceN = 0;
+                DerailmentCoefficient = 0;
+                DerailExpected = false;
+                DerailPossible = false;
+                DerailElapsedTimeS = 0;
+                return;
+            }
             // Calculate coupler angle when travelling around curve
             // To achieve an accurate coupler angle calculation the following length need to be calculated. These values can be included in the ENG/WAG file for greatest accuracy, or alternatively OR will
             // calculate some default values based upon the length of the car specified in the "Size" statement. This value may however be inaccurate, and sets the "visual" distance for placement of the 

--- a/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HUDWindow.cs
@@ -1239,7 +1239,7 @@ namespace Orts.Viewer3D.Popups
                 Viewer.Catalog.GetString("Brk Slide"),
                 Viewer.Catalog.GetString("Bear Temp"),
                 Viewer.Catalog.GetString(" "),
-                Viewer.Catalog.GetString("DerailCoeff")
+                Viewer.Settings.VisualDerailment ? Viewer.Catalog.GetString("DerailCoeff") : ""
                 
                 );
             TableAddLine(table);
@@ -1268,7 +1268,10 @@ namespace Orts.Viewer3D.Popups
                 TableSetCell(table, 16, car.HUDBrakeSkid ? Viewer.Catalog.GetString("Yes") : Viewer.Catalog.GetString("No"));
                 TableSetCell(table, 17, "{0} {1}", FormatStrings.FormatTemperature(car.WheelBearingTemperatureDegC, car.IsMetric, false), car.DisplayWheelBearingTemperatureStatus);
                 TableSetCell(table, 18, car.Flipped ? Viewer.Catalog.GetString("Flipped") : "");
-                TableSetCell(table, 19, "{0:F2}{1}", car.DerailmentCoefficient, car.DerailExpected ? "!!!" : car.DerailPossible ? "???" : "");
+                if (Viewer.Settings.VisualDerailment)
+                    TableSetCell(table, 19, "{0:F2}{1}", car.DerailmentCoefficient, car.DerailExpected ? "!!!" : car.DerailPossible ? "???" : "");
+                else
+                    TableSetCell(table, 19, "");
                 TableAddLine(table);
 
             }

--- a/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
@@ -255,8 +255,16 @@ namespace Orts.Viewer3D.Popups
             outf.Write(ctrlAIFiremanReset);
             outf.Write(clockWheelTime);
             outf.Write(wheelLabelVisible);
-            outf.Write(clockDerailTime);
-            outf.Write(derailLabelVisible);
+            if (Owner.Viewer.Settings.VisualDerailment)
+            {
+                outf.Write(clockDerailTime);
+                outf.Write(derailLabelVisible);
+            }
+            else
+            {
+                outf.Write(0.0);
+                outf.Write(false);
+            }
             outf.Write(clockDoorsTime);
             outf.Write(doorsLabelVisible);
         }
@@ -276,8 +284,18 @@ namespace Orts.Viewer3D.Popups
             ctrlAIFiremanReset = inf.ReadBoolean();
             clockWheelTime = inf.ReadDouble();
             wheelLabelVisible = inf.ReadBoolean();
-            clockDerailTime = inf.ReadDouble();
-            derailLabelVisible = inf.ReadBoolean();
+            if (Owner.Viewer.Settings.VisualDerailment)
+            {
+                clockDerailTime = inf.ReadDouble();
+                derailLabelVisible = inf.ReadBoolean();
+            }
+            else
+            {
+                inf.ReadDouble();
+                inf.ReadBoolean();
+                clockDerailTime = 0;
+                derailLabelVisible = false;
+            }
             clockDoorsTime = inf.ReadDouble();
             doorsLabelVisible = inf.ReadBoolean();
 
@@ -1519,68 +1537,71 @@ namespace Orts.Viewer3D.Popups
                 }
             }
 
-            //Derailment Coefficient. Changed the float value output by a text label.
-            var carIDerailCoeff = "";
-            var carDerailPossible = false;
-            var carDerailExpected = false;
-
-            for (var i = 0; i < train.Cars.Count; i++)
+            if (Viewer.Settings.VisualDerailment)
             {
-                var carDerailCoeff = train.Cars[i].DerailmentCoefficient;
-                carDerailCoeff = float.IsInfinity(carDerailCoeff) || float.IsNaN(carDerailCoeff) ? 0 : carDerailCoeff;
+                //Derailment Coefficient. Changed the float value output by a text label.
+                var carIDerailCoeff = "";
+                var carDerailPossible = false;
+                var carDerailExpected = false;
 
-                carIDerailCoeff = train.Cars[i].CarID;
+                for (var i = 0; i < train.Cars.Count; i++)
+                {
+                    var carDerailCoeff = train.Cars[i].DerailmentCoefficient;
+                    carDerailCoeff = float.IsInfinity(carDerailCoeff) || float.IsNaN(carDerailCoeff) ? 0 : carDerailCoeff;
 
-                // Only record the first car that has derailed, stop looking for other derailed cars
-                carDerailExpected = train.Cars[i].DerailExpected;
+                    carIDerailCoeff = train.Cars[i].CarID;
+
+                    // Only record the first car that has derailed, stop looking for other derailed cars
+                    carDerailExpected = train.Cars[i].DerailExpected;
+                    if (carDerailExpected)
+                    {
+                        break;
+                    }
+
+                    // Only record first instance of a possible car derailment (warning)
+                    if (train.Cars[i].DerailPossible && !carDerailPossible)
+                    {
+                        carDerailPossible = train.Cars[i].DerailPossible;
+                    }
+                }
+
+                if (carDerailPossible || carDerailExpected)
+                {
+                    derailLabelVisible = true;
+                    clockDerailTime = Owner.Viewer.Simulator.ClockTime;
+                }
+
+                // The most extreme instance of the derail coefficient will only be displayed in the TDW
                 if (carDerailExpected)
-                {
-                    break;
-                }
-
-                // Only record first instance of a possible car derailment (warning)
-                if (train.Cars[i].DerailPossible && !carDerailPossible)
-                {
-                    carDerailPossible = train.Cars[i].DerailPossible;
-                }
-            }
-
-            if (carDerailPossible || carDerailExpected)
-            {
-                derailLabelVisible = true;
-                clockDerailTime = Owner.Viewer.Simulator.ClockTime;
-            }
-
-            // The most extreme instance of the derail coefficient will only be displayed in the TDW
-            if (carDerailExpected)
-            {
-                AddLabel(new ListLabel
-                {
-                    FirstCol = Viewer.Catalog.GetString("DerailCoeff"),
-                    LastCol = $"{Viewer.Catalog.GetString("Derailed")} {carIDerailCoeff}" + ColorCode[Color.OrangeRed],
-                });
-            }
-            else if (carDerailPossible)
-            {
-                AddLabel(new ListLabel
-                {
-                    FirstCol = Viewer.Catalog.GetString("DerailCoeff"),
-                    LastCol = $"{Viewer.Catalog.GetString("Warning")} {carIDerailCoeff}" + ColorCode[Color.Yellow],
-                });
-            }
-            else
-            {
-                // delay to hide the derailcoeff label if normal
-                if (derailLabelVisible && clockDerailTime + 3 < Owner.Viewer.Simulator.ClockTime)
-                    derailLabelVisible = false;
-
-                if (derailLabelVisible)
                 {
                     AddLabel(new ListLabel
                     {
-                        FirstCol = Viewer.Catalog.GetString("DerailCoeff") + ColorCode[Color.White],
-                        LastCol = Viewer.Catalog.GetString("Normal") + ColorCode[Color.White]
+                        FirstCol = Viewer.Catalog.GetString("DerailCoeff"),
+                        LastCol = $"{Viewer.Catalog.GetString("Derailed")} {carIDerailCoeff}" + ColorCode[Color.OrangeRed],
                     });
+                }
+                else if (carDerailPossible)
+                {
+                    AddLabel(new ListLabel
+                    {
+                        FirstCol = Viewer.Catalog.GetString("DerailCoeff"),
+                        LastCol = $"{Viewer.Catalog.GetString("Warning")} {carIDerailCoeff}" + ColorCode[Color.Yellow],
+                    });
+                }
+                else
+                {
+                    // delay to hide the derailcoeff label if normal
+                    if (derailLabelVisible && clockDerailTime + 3 < Owner.Viewer.Simulator.ClockTime)
+                        derailLabelVisible = false;
+
+                    if (derailLabelVisible)
+                    {
+                        AddLabel(new ListLabel
+                        {
+                            FirstCol = Viewer.Catalog.GetString("DerailCoeff") + ColorCode[Color.White],
+                            LastCol = Viewer.Catalog.GetString("Normal") + ColorCode[Color.White]
+                        });
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- add `VisualDerailment` experimental setting
- expose option in Experimental tab to toggle visual derailment
- run derailment physics and UI only when setting enabled

## Testing
- `dotnet build Source/ORTS.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fc0e398c8324a4859a7901bc7599