### PR TITLE
Handle derailment restart flow

### DIFF
--- a/Source/Locales/RunActivity/RunActivity.pot
+++ b/Source/Locales/RunActivity/RunActivity.pot
@@ -3090,6 +3090,10 @@ msgstr ""
 msgid "Derailed"
 msgstr ""
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr ""
+
 #: ../../RunActivity/Viewer3D/Popups/TrainListWindow.cs:33
 msgid "Train List"
 msgstr ""

--- a/Source/Locales/RunActivity/cs.po
+++ b/Source/Locales/RunActivity/cs.po
@@ -12,6 +12,10 @@ msgstr ""
 "X-Generator: Poedit 1.8.4\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr "Train has derailed, restart simulation"
+
 #: ../../RunActivity/AI/AITrain.cs:6100
 #: ../../RunActivity/Simulator/Activity.cs:891
 #: ../../RunActivity/Timetable/TTTrain.cs:5792

--- a/Source/Locales/RunActivity/da.po
+++ b/Source/Locales/RunActivity/da.po
@@ -12,6 +12,10 @@ msgstr ""
 "X-Generator: Poedit 1.6.4\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr "Train has derailed, restart simulation"
+
 #: ../../RunActivity/Common/Scripting/BrakeController.cs:217
 #: ../../RunActivity/RollingStock/SubSystems/Brakes/MSTS/AirSinglePipe.cs:55
 msgid "Release"

--- a/Source/Locales/RunActivity/de.po
+++ b/Source/Locales/RunActivity/de.po
@@ -12,6 +12,10 @@ msgstr ""
 "X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr "Train has derailed, restart simulation"
+
 #: ../../RunActivity/Viewer3D/Cameras.cs:601
 msgid "Free"
 msgstr "Frei beweglich"

--- a/Source/Locales/RunActivity/fr.po
+++ b/Source/Locales/RunActivity/fr.po
@@ -12,6 +12,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr "Train has derailed, restart simulation"
+
 #: ../../RunActivity/Viewer3D/Cameras.cs:601
 msgid "Free"
 msgstr "Libre"

--- a/Source/Locales/RunActivity/hu.po
+++ b/Source/Locales/RunActivity/hu.po
@@ -12,6 +12,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.3.2\n"
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr "Train has derailed, restart simulation"
+
 #: ../../RunActivity/Viewer3D/Cameras.cs:601
 msgid "Free"
 msgstr "Szabadmozgatású"

--- a/Source/Locales/RunActivity/it.po
+++ b/Source/Locales/RunActivity/it.po
@@ -12,6 +12,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.1.1\n"
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr "Train has derailed, restart simulation"
+
 #: ../../RunActivity/Viewer3D/Cameras.cs:601
 msgid "Free"
 msgstr "Libero"

--- a/Source/Locales/RunActivity/pt-BR.po
+++ b/Source/Locales/RunActivity/pt-BR.po
@@ -12,6 +12,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Language: pt-BR\n"
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr "Train has derailed, restart simulation"
+
 #: ../../RunActivity/Viewer3D/Cameras.cs:598
 msgid "Free"
 msgstr "Livre"

--- a/Source/Locales/RunActivity/qps-ploc.po
+++ b/Source/Locales/RunActivity/qps-ploc.po
@@ -12,6 +12,10 @@ msgstr ""
 "X-Generator: PowerShell Update-Pseudo.ps1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr "Train has derailed, restart simulation"
+
 
 #: ../../RunActivity/Viewer3D/Cameras.cs:601
 msgid "Free"

--- a/Source/Locales/RunActivity/ru.po
+++ b/Source/Locales/RunActivity/ru.po
@@ -13,6 +13,10 @@ msgstr ""
 "n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "X-Generator: Poedit 3.2.2\n"
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr "Train has derailed, restart simulation"
+
 #: ../../RunActivity/Viewer3D/Cameras.cs:601
 msgid "Free"
 msgstr "Свободная"

--- a/Source/Locales/RunActivity/zh-CN.po
+++ b/Source/Locales/RunActivity/zh-CN.po
@@ -12,6 +12,10 @@ msgstr ""
 "X-Generator: Poedit 1.7.5\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+#: ../../RunActivity/Viewer3D/Viewer.cs:227
+msgid "DerailRestart"
+msgstr "Train has derailed, restart simulation"
+
 #: ../../RunActivity/Common/Scripting/BrakeController.cs:217
 #: ../../RunActivity/RollingStock/MSTSSteamLocomotive.cs:3635
 #: ../../RunActivity/RollingStock/SubSystems/Brakes/MSTS/AirSinglePipe.cs:55

--- a/Source/RunActivity/Viewer3D/Cameras.cs
+++ b/Source/RunActivity/Viewer3D/Cameras.cs
@@ -55,6 +55,11 @@ namespace Orts.Viewer3D
         protected int MouseScrollValue;
         protected internal float FieldOfView;
 
+        /// <summary>
+        /// When set, camera translation commands are ignored. Rotation is still allowed.
+        /// </summary>
+        public bool TranslationLocked { get; set; }
+
         protected Matrix xnaView;
         public Matrix XnaView { get { return xnaView; } }
 

--- a/Source/RunActivity/Viewer3D/Commands.cs
+++ b/Source/RunActivity/Viewer3D/Commands.cs
@@ -544,7 +544,7 @@ namespace Orts.Viewer3D
 
         public override void Redo()
         {
-            if (Receiver.Camera is RotatingCamera)
+            if (!Receiver.Camera.TranslationLocked && Receiver.Camera is RotatingCamera)
             {
                 var c = Receiver.Camera as RotatingCamera;
                 c.RotationXTargetRadians = RotationXRadians;
@@ -573,7 +573,7 @@ namespace Orts.Viewer3D
 
         public override void Redo()
         {
-            if (Receiver.Camera is RotatingCamera)
+            if (!Receiver.Camera.TranslationLocked && Receiver.Camera is RotatingCamera)
             {
                 var c = Receiver.Camera as RotatingCamera;
                 c.RotationYTargetRadians = RotationYRadians;
@@ -607,7 +607,7 @@ namespace Orts.Viewer3D
 
         public override void Redo()
         {
-            if (Receiver.Camera is RotatingCamera)
+            if (!Receiver.Camera.TranslationLocked && Receiver.Camera is RotatingCamera)
             {
                 var c = Receiver.Camera as RotatingCamera;
                 c.EndTime = EndTime;
@@ -637,7 +637,7 @@ namespace Orts.Viewer3D
 
         public override void Redo()
         {
-            if (Receiver.Camera is RotatingCamera)
+            if (!Receiver.Camera.TranslationLocked && Receiver.Camera is RotatingCamera)
             {
                 var c = Receiver.Camera as RotatingCamera;
                 c.XTargetRadians = XRadians;
@@ -666,7 +666,7 @@ namespace Orts.Viewer3D
 
         public override void Redo()
         {
-            if (Receiver.Camera is RotatingCamera)
+            if (!Receiver.Camera.TranslationLocked && Receiver.Camera is RotatingCamera)
             {
                 var c = Receiver.Camera as RotatingCamera;
                 c.YTargetRadians = YRadians;
@@ -695,7 +695,7 @@ namespace Orts.Viewer3D
 
         public override void Redo()
         {
-            if (Receiver.Camera is RotatingCamera)
+            if (!Receiver.Camera.TranslationLocked && Receiver.Camera is RotatingCamera)
             {
                 var c = Receiver.Camera as RotatingCamera;
                 c.ZTargetRadians = ZRadians;
@@ -723,7 +723,7 @@ namespace Orts.Viewer3D
 
 		public override void Redo()
 		{
-			if (Receiver.Camera is ThreeDimCabCamera)
+                        if (!Receiver.Camera.TranslationLocked && Receiver.Camera is ThreeDimCabCamera)
 			{
 				var c = Receiver.Camera as ThreeDimCabCamera;
 				c.MoveCameraXYZ(X, Y, Z);
@@ -752,7 +752,7 @@ namespace Orts.Viewer3D
 
         public override void Redo()
         {
-            if (Receiver.Camera is TrackingCamera)
+            if (!Receiver.Camera.TranslationLocked && Receiver.Camera is TrackingCamera)
             {
                 var c = Receiver.Camera as TrackingCamera;
                 c.PositionXTargetRadians = PositionXRadians;
@@ -781,7 +781,7 @@ namespace Orts.Viewer3D
 
         public override void Redo()
         {
-            if (Receiver.Camera is TrackingCamera)
+            if (!Receiver.Camera.TranslationLocked && Receiver.Camera is TrackingCamera)
             {
                 var c = Receiver.Camera as TrackingCamera;
                 c.PositionYTargetRadians = PositionYRadians;
@@ -810,7 +810,7 @@ namespace Orts.Viewer3D
 
         public override void Redo()
         {
-            if (Receiver.Camera is TrackingCamera)
+            if (!Receiver.Camera.TranslationLocked && Receiver.Camera is TrackingCamera)
             {
                 var c = Receiver.Camera as TrackingCamera;
                 c.PositionDistanceTargetMetres = PositionDistanceMetres;

--- a/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/TrainDrivingWindow.cs
@@ -1535,6 +1535,7 @@ namespace Orts.Viewer3D.Popups
                 carDerailExpected = train.Cars[i].DerailExpected;
                 if (carDerailExpected)
                 {
+                    Owner.Viewer.StartDerailmentSequence();
                     break;
                 }
 

--- a/Source/RunActivity/Viewer3D/Viewer.cs
+++ b/Source/RunActivity/Viewer3D/Viewer.cs
@@ -111,6 +111,10 @@ namespace Orts.Viewer3D
         private OutOfFocusWindow OutOfFocusWindow; // to show colored rectangle around the main window when not in focus
         public EditorShapes EditorShapes { get; set; }
 
+        // Derailed session handling
+        public bool DerailmentSequenceActive { get; private set; }
+        double derailmentMessageTime;
+
         // Route Information
         public TileManager Tiles { get; private set; }
         public TileManager LoTiles { get; private set; }
@@ -198,6 +202,34 @@ namespace Orts.Viewer3D
 
         public bool SaveScreenshot { get; set; }
         public bool SaveActivityThumbnail { get; private set; }
+
+        /// <summary>
+        /// Initiates camera and timer handling when a car derails.
+        /// </summary>
+        public void StartDerailmentSequence()
+        {
+            if (DerailmentSequenceActive)
+                return;
+
+            FrontCamera.Activate();
+            Camera.TranslationLocked = true;
+            DerailmentSequenceActive = true;
+            derailmentMessageTime = Simulator.ClockTime + 10;
+        }
+
+        void UpdateDerailment()
+        {
+            if (!DerailmentSequenceActive)
+                return;
+
+            if (Simulator.ClockTime >= derailmentMessageTime)
+            {
+                Simulator.Confirmer.Message(ConfirmLevel.Error, Catalog.GetString("DerailRestart"));
+                if (QuitWindow != null)
+                    QuitWindow.Visible = Simulator.Paused = true;
+                DerailmentSequenceActive = false;
+            }
+        }
         public string SaveActivityFileStem { get; private set; }
 
         public Vector3 NearPoint { get; private set; }
@@ -827,6 +859,7 @@ namespace Orts.Viewer3D
             }
 
             World.Update(elapsedTime);
+            UpdateDerailment();
 
             if (frame.IsScreenChanged)
                 Camera.ScreenChanged();


### PR DESCRIPTION
## Summary
- Switch to outside camera and freeze translation when a car derails
- After 10 seconds prompt to restart and pause the session
- Add DerailRestart message key across locales

## Testing
- `dotnet build Source/RunActivity/RunActivity.csproj` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fc0c7190832490efe0ed884f12d2