### PR TITLE
Track full timetable, show in F1 help window, and refine clock multiplier handling

### DIFF
--- a/Source/Orts.Formats.OR/DrawUtility.cs
+++ b/Source/Orts.Formats.OR/DrawUtility.cs
@@ -258,7 +258,7 @@ namespace Orts.Formats.OR
             return pt;
         }
 #if false
-		        public static PointF FindStraightIntersection(AESegment segArea, AESegment track)
+        public static PointF FindStraightIntersection(AESegment segArea, AESegment track)
         {
             float xD1, yD1, xD2, yD2, xD3, yD3;
             double dot, deg;
@@ -266,7 +266,7 @@ namespace Orts.Formats.OR
             double segmentLen1, segmentLen2;
             float ua, ub, div;
 
-            // calculate differences  
+            // calculate differences
             xD1 = segArea.endPoint.X - segArea.startPoint.X;
             xD2 = track.endPoint.X - track.startPoint.X;
             yD1 = segArea.endPoint.Y - segArea.startPoint.Y;
@@ -274,35 +274,20 @@ namespace Orts.Formats.OR
             xD3 = segArea.startPoint.X - track.startPoint.X;
             yD3 = segArea.startPoint.Y - track.startPoint.Y;
 
-            // calculate the lengths of the two lines  
+            // calculate the lengths of the two lines
             len1 = Math.Sqrt(xD1 * xD1 + yD1 * yD1);
             len2 = Math.Sqrt(xD2 * xD2 + yD2 * yD2);
 
-            // calculate angle between the two lines.  
-            dot = (xD1 * xD2 + yD1 * yD2); // dot product  
+            // calculate angle between the two lines.
+            dot = (xD1 * xD2 + yD1 * yD2); // dot product
             deg = dot / (len1 * len2);
 
-            // if abs(angle)==1 then the lines are parallell,  
-            // so no intersection is possible  
-            if (Math.Abs(deg) == 1) 
-=======
-            // find intersection Pt between two lines    
-            PointF pt = new PointF(0, 0);
-            div = yD2 * xD1 - xD2 * yD1;
-            if (div == 0)
->>>>>>> .r37
+            // if abs(angle)==1 then the lines are parallel,
+            // so no intersection is possible
+            if (Math.Abs(deg) == 1)
                 return PointF.Empty;
-<<<<<<< .mine
-=======
-            ua = (xD2 * yD3 - yD2 * xD3) / div;
-            ub = (xD1 * yD3 - yD1 * xD3) / div;
-            pt.Y = segArea.startPoint.Y + ub * yD1;
-            pt.X = segArea.startPoint.X + ua * xD1;
-            pt.Y = segArea.startPoint.Y + ua * yD1;
->>>>>>> .r37
 
-<<<<<<< .mine
-            // find intersection Pt between two lines    
+            // find intersection Pt between two lines
             PointF pt = new PointF(0, 0);
             div = yD2 * xD1 - xD2 * yD1;
             if (div == 0)
@@ -312,74 +297,40 @@ namespace Orts.Formats.OR
             pt.Y = segArea.startPoint.Y + ub * yD1;
             pt.X = segArea.startPoint.X + ua * xD1;
             pt.Y = segArea.startPoint.Y + ua * yD1;
-=======
-            // calculate the combined length of the two segments  
-            // between Pt-p1 and Pt-p2  
-            xD1 = pt.X - segArea.startPoint.X;
-            xD2 = pt.X - segArea.endPoint.X;
-            yD1 = pt.Y - segArea.startPoint.Y;
-            yD2 = pt.Y - segArea.endPoint.Y;
-            segmentLen1 = Math.Sqrt(xD1 * xD1 + yD1 * yD1) + Math.Sqrt(xD2 * xD2 + yD2 * yD2);
->>>>>>> .r37
 
-<<<<<<< .mine
-            // calculate the combined length of the two segments  
-            // between Pt-p1 and Pt-p2  
+            // calculate the combined length of the two segments
+            // between Pt-p1 and Pt-p2
             xD1 = pt.X - segArea.startPoint.X;
             xD2 = pt.X - segArea.endPoint.X;
             yD1 = pt.Y - segArea.startPoint.Y;
             yD2 = pt.Y - segArea.endPoint.Y;
             segmentLen1 = Math.Sqrt(xD1 * xD1 + yD1 * yD1) + Math.Sqrt(xD2 * xD2 + yD2 * yD2);
 
-            // calculate the combined length of the two segments  
-            // between Pt-p3 and Pt-p4  
+            // calculate the combined length of the two segments
+            // between Pt-p3 and Pt-p4
             xD1 = pt.X - track.startPoint.X;
             xD2 = pt.X - track.endPoint.X;
             yD1 = pt.Y - track.startPoint.Y;
             yD2 = pt.Y - track.endPoint.Y;
             segmentLen2 = Math.Sqrt(xD1 * xD1 + yD1 * yD1) + Math.Sqrt(xD2 * xD2 + yD2 * yD2);
 
-            // if the lengths of both sets of segments are the same as  
-            // the lenghts of the two lines the point is actually   
-            // on the line segment.  
+            // if the lengths of both sets of segments are the same as
+            // the lengths of the two lines the point is actually
+            // on the line segment.
 
-            // if the point isn't on the line, return null  
+            // if the point isn't on the line, return null
             if (Math.Abs(len1 - segmentLen1) > 0.01 || Math.Abs(len2 - segmentLen2) > 0.01)
                 return PointF.Empty;
 
-            // return the valid intersection  
+            // return the valid intersection
             if (pt.IsEmpty)
                 return PointF.Empty;
             if (FindDistancePoints(pt, segArea.startPoint) < 0.1 || FindDistancePoints(pt, segArea.endPoint) < 0.1)
                 return PointF.Empty;
             return pt;
-=======
-            // calculate the combined length of the two segments  
-            // between Pt-p3 and Pt-p4  
-            xD1 = pt.X - track.startPoint.X;
-            xD2 = pt.X - track.endPoint.X;
-            yD1 = pt.Y - track.startPoint.Y;
-            yD2 = pt.Y - track.endPoint.Y;
-            segmentLen2 = Math.Sqrt(xD1 * xD1 + yD1 * yD1) + Math.Sqrt(xD2 * xD2 + yD2 * yD2);
-
-            // if the lengths of both sets of segments are the same as  
-            // the lenghts of the two lines the point is actually   
-            // on the line segment.  
-
-            // if the point isn't on the line, return null  
-            if (Math.Abs(len1 - segmentLen1) > 0.01 || Math.Abs(len2 - segmentLen2) > 0.01)
-                return PointF.Empty;
-
-            // return the valid intersection  
-            if (pt.IsEmpty)
-                return PointF.Empty;
-            if (FindDistancePoints(pt, segArea.startPoint) < 0.1 || FindDistancePoints(pt, segArea.endPoint) < 0.1)
-                return PointF.Empty;
-            return pt;
->>>>>>> .r37
         }
-  
-	#endif
+
+#endif
         public static PointF FindCurveIntersection(AESegment segArea, AESegment track)
         {
             PointF pointA = track.startPoint;

--- a/Source/Orts.Simulation/Simulation/AIs/AI.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AI.cs
@@ -51,7 +51,7 @@ namespace Orts.Simulation.AIs
         public StartTrains StartList = new StartTrains(); // Trains yet to be started
         public List<AITrain> AutoGenTrains = new List<AITrain>(); // Auto-generated trains
         public double clockTime; // Clock time: local time before activity start, common time from simulator after start
-        public float clockmult = 1; // default clock multiplier joe179star
+        public float ClockMultiplier = 1f; // Default clock multiplier
         private bool localTime;  // If true: clockTime is local time
         public List<AITrain> TrainsToRemove = new List<AITrain>();
         public List<AITrain> TrainsToAdd = new List<AITrain>();
@@ -332,7 +332,7 @@ namespace Orts.Simulation.AIs
 
                 // Perform update for AI trains upto actual start time
                 clockTime = firstAITime - 1.0f;
-                clockmult = Simulator.clockmult; //joe179star
+                ClockMultiplier = Simulator.ClockMultiplier;
                 localTime = true;
                 Simulator.PreUpdate = true;
 
@@ -341,7 +341,7 @@ namespace Orts.Simulation.AIs
                     int fullsec = Convert.ToInt32(runTime);
                     if (fullsec % 3600 == 0) Trace.Write(" " + (fullsec / 3600).ToString("00") + ":00 ");
 
-                    AIUpdate((float)((runTime - clockTime) / clockmult), Simulator.PreUpdate); //joe179star
+                    AIUpdate((float)((runTime - clockTime) / ClockMultiplier), Simulator.PreUpdate);
                     Simulator.Signals.Update(true);
                     clockTime = runTime;
                     if (cancellation.IsCancellationRequested) return; // Ping watchdog process
@@ -361,11 +361,12 @@ namespace Orts.Simulation.AIs
 
                 // Perform update for AI trains upto actual start time
                 clockTime = firstAITime - 1.0f;
-                clockmult = TTTrain.clockmult / 10.0f; //joe179star
+                ClockMultiplier = TTTrain.ClockMultiplier / 10.0f;
                 localTime = true;
                 Simulator.PreUpdate = true;
                 bool activeTrains = false;
-                for (double runTime = firstAITime; runTime < Simulator.ClockTime && !endPreRun; runTime += 30.0) // joe179star update with 30 secs interval - default 5
+                // Update with 30-second intervals (default was 5)
+                for (double runTime = firstAITime; runTime < Simulator.ClockTime && !endPreRun; runTime += 30.0)
                 {
                     var loaderSpan = (float)TimetableInfo.PlayerTrainOriginalStartTime - firstAITime;
                     Simulator.TimetableLoadedFraction = ((float)runTime - firstAITime) / loaderSpan;
@@ -373,7 +374,7 @@ namespace Orts.Simulation.AIs
                     int fullsec = Convert.ToInt32(runTime);
                     if (fullsec % 3600 < 5) Trace.Write(" " + (fullsec / 3600).ToString("00") + ":00 ");
 
-                    endPreRun = AITTUpdate((float)((runTime - clockTime) / clockmult), Simulator.PreUpdate, ref activeTrains); //joe179star
+                    endPreRun = AITTUpdate((float)((runTime - clockTime) / ClockMultiplier), Simulator.PreUpdate, ref activeTrains);
 
                     if (activeTrains)
                     {
@@ -535,7 +536,7 @@ namespace Orts.Simulation.AIs
 
                     while (!playerTrainStarted)
                     {
-                        endPreRun = AITTUpdate((float)((runTime - clockTime) / clockmult), Simulator.PreUpdate, ref dummy); //joe179star
+                        endPreRun = AITTUpdate((float)((runTime - clockTime) / ClockMultiplier), Simulator.PreUpdate, ref dummy);
                         Simulator.Signals.Update(true);
                         clockTime = runTime;
                         runTime += deltaTime;

--- a/Source/Orts.Simulation/Simulation/AIs/AI.cs
+++ b/Source/Orts.Simulation/Simulation/AIs/AI.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Orts.Formats.Msts;
 using Orts.MultiPlayer;
 using Orts.Simulation.Physics;

--- a/Source/Orts.Simulation/Simulation/Simulator.cs
+++ b/Source/Orts.Simulation/Simulation/Simulator.cs
@@ -81,8 +81,10 @@ namespace Orts.Simulation
         // while Simulator.Update() is running, objects are adjusted to this target time 
         // after Simulator.Update() is complete, the simulator state matches this time
 
-        public float clockmult = 1;
-        // clock multiplier modification for compressed mileage routes. Default is equal to 1 (standard time) joe179star
+        /// <summary>
+        /// Multiplier applied to the simulation clock; 1 runs at real-time speed.
+        /// </summary>
+        public float ClockMultiplier = 1f;
 
         public readonly UserSettings Settings;
 
@@ -404,7 +406,7 @@ namespace Orts.Simulation
             StartTime st = Activity.Tr_Activity.Tr_Activity_Header.StartTime;
             TimeSpan StartTime = new TimeSpan(st.Hour, st.Minute, st.Second);
             ClockTime = StartTime.TotalSeconds;
-            clockmult = Activity.Tr_Activity.Tr_Activity_File.ORTSActClockSpeed / 10.0f; //joe179star
+            ClockMultiplier = Activity.Tr_Activity.Tr_Activity_File.ORTSActClockSpeed / 10.0f;
             Season = Activity.Tr_Activity.Tr_Activity_Header.Season;
             WeatherType = Activity.Tr_Activity.Tr_Activity_Header.Weather;
             if (Activity.Tr_Activity.Tr_Activity_File.ActivityRestrictedSpeedZones != null)
@@ -826,8 +828,9 @@ namespace Orts.Simulation
         {
             // Advance the times.
             GameTime += elapsedClockSeconds;
-            if (TimetableMode == true) clockmult = TTTrain.clockmult / 10.0f; //joe179star
-            ClockTime += elapsedClockSeconds * clockmult;
+            if (TimetableMode)
+                ClockMultiplier = TTTrain.ClockMultiplier / 10.0f;
+            ClockTime += elapsedClockSeconds * ClockMultiplier;
 
             // Check if there is a request to switch to another played train
 

--- a/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
@@ -54,7 +54,7 @@ namespace Orts.Simulation.Timetables
             trainDefinition,
             trainAddInfo,
             invalid,
-            clockmult,
+            clockMultiplier,
         }
 
         private enum rowType
@@ -73,7 +73,7 @@ namespace Orts.Simulation.Timetables
             comment,
             briefing,
             invalid,
-            clockmult,
+            clockMultiplier,
         }
 
         Dictionary<string, AIPath> Paths = new Dictionary<string, AIPath>();             // Original path referenced by path name
@@ -333,8 +333,8 @@ namespace Orts.Simulation.Timetables
             int disposeRow = -1;
             int briefingRow = -1;
 
-            int firstclockmultRow = -1; //joe179star
-            int firstclockmultColumn = -1; //joe179star
+            int firstClockMultiplierRow = -1;
+            int firstClockMultiplierColumn = -1;
 
             int firstCommentRow = -1;
             int firstCommentColumn = -1;
@@ -371,8 +371,8 @@ namespace Orts.Simulation.Timetables
                             ColInfo[iColumn] = columnType.comment;
                             break;
 
-                        case columnType.clockmult: //joe179star
-                            ColInfo[iColumn] = columnType.clockmult;
+                        case columnType.clockMultiplier:
+                            ColInfo[iColumn] = columnType.clockMultiplier;
                             break;
 
                         case columnType.trainDefinition:
@@ -388,11 +388,13 @@ namespace Orts.Simulation.Timetables
                 }
                 else if (String.Compare(columnDef, "#comment", true) == 0)
                 {
-                    // Comment & clockmult joe179star
                     ColInfo[iColumn] = columnType.comment;
                     if (firstCommentColumn < 0) firstCommentColumn = iColumn;
-                    ColInfo[iColumn] = columnType.clockmult;
-                    if (firstclockmultColumn < 0) firstclockmultColumn = iColumn;
+                }
+                else if (String.Compare(columnDef, "#clockmult", true) == 0)
+                {
+                    ColInfo[iColumn] = columnType.clockMultiplier;
+                    if (firstClockMultiplierColumn < 0) firstClockMultiplierColumn = iColumn;
                 }
 
                 else if (columnDef.Substring(0, 1).Equals("#"))
@@ -540,18 +542,9 @@ namespace Orts.Simulation.Timetables
                             briefingRow = iRow;
                             break;
 
-                        case "#clockmult": //joe179star
-                            RowInfo[iRow] = rowType.clockmult;
-                            if (firstclockmultRow < 0) firstclockmultRow = iRow;
-                            if (firstclockmultRow < 0)
-                            {
-                                Trace.TraceInformation("no clockmult found \n");
-                                TTTrain.clockmult = 10;
-                            }
-                            else
-                            {
-                                Trace.TraceInformation("firstclockmult firstclockcol {0} {1}", firstclockmultRow, firstclockmultColumn);
-                            }
+                        case "#clockmult":
+                            RowInfo[iRow] = rowType.clockMultiplier;
+                            if (firstClockMultiplierRow < 0) firstClockMultiplierRow = iRow;
                             break;
 
                         default:  // default is station definition
@@ -631,17 +624,11 @@ namespace Orts.Simulation.Timetables
             string description = (firstCommentRow >= 0 && firstCommentColumn >= 0) ?
                 fileContents.Strings[firstCommentRow][firstCommentColumn] : Path.GetFileNameWithoutExtension(fileContents.FilePath);
 
-            // extract clock multiplier joe179star
-
-            string clockmultinfo = (firstclockmultRow >= 0 && firstclockmultColumn >= 0) ?
-                fileContents.Strings[firstclockmultRow][firstclockmultColumn] : Path.GetFileNameWithoutExtension(fileContents.FilePath);
-            Trace.TraceWarning("clock multiplier string: {0}", clockmultinfo);
-            if (clockmultinfo == null)
-            {
-                clockmultinfo = "10";
-            }
-            TTTrain.clockmult = Int32.Parse(clockmultinfo);
-            Trace.TraceWarning("clock multiplier integer: {0}", TTTrain.clockmult);
+            // Extract clock multiplier (defaults to 10 if not specified)
+            string clockMultiplierInfo = (firstClockMultiplierRow >= 0 && firstClockMultiplierColumn >= 0) ?
+                fileContents.Strings[firstClockMultiplierRow][firstClockMultiplierColumn] : "10";
+            if (!int.TryParse(clockMultiplierInfo, out TTTrain.ClockMultiplier))
+                TTTrain.ClockMultiplier = 10;
 
             // Extract additional station info
             for (int iRow = 1; iRow <= fileContents.Strings.Count - 1; iRow++)

--- a/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/ProcessTimetable.cs
@@ -29,6 +29,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Orts.Formats.Msts;
 using Orts.Formats.OR;
 using Orts.Parsers.OR;

--- a/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
+++ b/Source/Orts.Simulation/Simulation/Timetables/TTTrain.cs
@@ -61,7 +61,8 @@ namespace Orts.Simulation.Timetables
         public static float keepDistanceTrainAheadCloseupM = 0.5f; // Stay 0.5m from train ahead when closeup required (for stabling only)
         public static float keepDistanceCloseupSignalM = 7.0f;     // Stay 10m from signal ahead when signalcloseup required
         public static float endOfRouteDistance = 150f;             // Max length to remain for train to continue on route
-        public static int clockmult = 10;                           //joe179star default clock multiplier (normal speed)
+        // Default clock multiplier (normal speed)
+        public static int ClockMultiplier = 10;
 
         public int? ActivateTime;                        // Time train is activated
         public bool TriggeredActivationRequired = false; // Train activation is triggered by other train
@@ -146,6 +147,9 @@ namespace Orts.Simulation.Timetables
         public Dictionary<int, List<int>> NeedStationTransfer = new Dictionary<int, List<int>>();
         // Number of required train transfers per section
         public Dictionary<int, int> NeedTrainTransfer = new Dictionary<int, int>();
+
+        // All station stops in original timetable order
+        public List<StationStop> AllStationStops = new List<StationStop>();
 
         /* Delayed restart */
         public bool DelayedStart = false;                   // Start is delayed
@@ -537,7 +541,7 @@ namespace Orts.Simulation.Timetables
 
             Briefing = inf.ReadString();
 
-            clockmult = inf.ReadInt32(); //joe179star
+            ClockMultiplier = inf.ReadInt32();
 
             // Reset actions if train is active
             bool activeTrain = true;
@@ -849,7 +853,7 @@ namespace Orts.Simulation.Timetables
             outf.Write(DriverOnlyOperation);
             outf.Write(ForceReversal);
             outf.Write(Briefing);
-            outf.Write(clockmult); //joe179star
+            outf.Write(ClockMultiplier);
         }
 
         //================================================================================================//
@@ -1065,6 +1069,7 @@ namespace Orts.Simulation.Timetables
                         if (newStop.RouteIndex >= 0)
                         {
                             StationStops.Add(newStop); // Do not set stop if platform is not on route
+                            AllStationStops.Add(newStop);
 
                             // Switch stop position if train is to reverse
                             int nextTrainRouteIndex = nextTrain.TCRoute.TCRouteSubpaths[0].GetRouteIndex(lastSectionIndex, 0);
@@ -2017,6 +2022,7 @@ namespace Orts.Simulation.Timetables
                 int EndSignal = thisStation.ExitSignal;
 
                 StationStops.Add(thisStation);
+                AllStationStops.Add(thisStation);
 
                 // If station has hold signal and this signal is the same as the exit signal for previous station, remove the exit signal from the previous station
                 if (HoldSignal && StationStops.Count > 1)
@@ -2829,7 +2835,7 @@ namespace Orts.Simulation.Timetables
                         }
                         else
                         {
-                            dyndelayspeed = MathHelper.Clamp(clockmult * StationStops[0].DistanceToTrainM / (10 * (StationStops[0].ArrivalTime - correctedTime - delaysec)), 0.0f, 200.0f);
+                            dyndelayspeed = MathHelper.Clamp(ClockMultiplier * StationStops[0].DistanceToTrainM / (10 * (StationStops[0].ArrivalTime - correctedTime - delaysec)), 0.0f, 200.0f);
                         }
                         //Trace.TraceInformation("minimal delay dyndelayspeed {0} stationtime {1} stationdist {2} correctedtime {3} presenttime {4} delay {5} Name {6}", Convert.ToInt32(dyndelayspeed), StationStops[0].ArrivalTime, StationStops[0].DistanceToTrainM, correctedTime, presentTime, delaysec, Name);
                         if (dyndelayspeed < 1.0f)
@@ -10294,6 +10300,11 @@ namespace Orts.Simulation.Timetables
         public void SetupStationStopHandling()
         {
             CheckStations = true; // Set station stops to be handled by train
+
+            if (AllStationStops.Count == 0 && StationStops != null)
+            {
+                AllStationStops.AddRange(StationStops);
+            }
 			
             // Check if initial at station
             if (StationStops.Count > 0)

--- a/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
@@ -564,6 +564,41 @@ namespace Orts.Viewer3D.Popups
                     var textFlow = new TextFlow(scrollbox.RemainingWidth, briefing);
                     scrollbox.Add(textFlow);
                 }));
+
+                Tabs.Add(new TabData(Tab.Timetable, Viewer.Catalog.GetString("Timetable"), (cl) =>
+                {
+                    var colWidth = (cl.RemainingWidth - cl.TextHeight) / 7;
+                    {
+                        var line = cl.AddLayoutHorizontalLineOfText();
+                        line.Add(new Label(colWidth * 3, line.RemainingHeight, Viewer.Catalog.GetString("Station")));
+                        line.Add(new Label(colWidth, line.RemainingHeight, Viewer.Catalog.GetString("Arrive"), LabelAlignment.Center));
+                        line.Add(new Label(colWidth, line.RemainingHeight, Viewer.Catalog.GetString("Actual"), LabelAlignment.Center));
+                        line.Add(new Label(colWidth, line.RemainingHeight, Viewer.Catalog.GetString("Depart"), LabelAlignment.Center));
+                        line.Add(new Label(colWidth, line.RemainingHeight, Viewer.Catalog.GetString("Actual"), LabelAlignment.Center));
+                    }
+                    cl.AddHorizontalSeparator();
+                    var scrollbox = cl.AddLayoutScrollboxVertical(cl.RemainingWidth);
+                    var tTTrain = owner.Viewer.SelectedTrain as Orts.Simulation.Timetables.TTTrain;
+                    if (tTTrain != null && tTTrain.AllStationStops != null)
+                    {
+                        foreach (var stop in tTTrain.AllStationStops)
+                        {
+                            Label arriveLabel, departLabel;
+                            var line = scrollbox.AddLayoutHorizontalLineOfText();
+                            line.Add(new Label(colWidth * 3, line.RemainingHeight, stop.PlatformItem.Name));
+                            line.Add(new Label(colWidth, line.RemainingHeight, stop.arrivalDT.ToString("HH:mm:ss"), LabelAlignment.Center));
+                            DateTime? actArr = stop.ActualArrival >= 0 ? new DateTime((long)(Math.Pow(10, 7) * stop.ActualArrival)) : (DateTime?)null;
+                            string actArrText = actArr.HasValue ? actArr.Value.ToString("HH:mm:ss") : stop.Passed ? Viewer.Catalog.GetString("(missed)") : "";
+                            line.Add(arriveLabel = new Label(colWidth, line.RemainingHeight, actArrText, LabelAlignment.Center));
+                            line.Add(new Label(colWidth, line.RemainingHeight, stop.departureDT.ToString("HH:mm:ss"), LabelAlignment.Center));
+                            DateTime? actDep = stop.ActualDepart >= 0 ? new DateTime((long)(Math.Pow(10, 7) * stop.ActualDepart)) : (DateTime?)null;
+                            string actDepText = actDep.HasValue ? actDep.Value.ToString("HH:mm:ss") : stop.Passed ? Viewer.Catalog.GetString("(missed)") : "";
+                            line.Add(departLabel = new Label(colWidth, line.RemainingHeight, actDepText, LabelAlignment.Center));
+                            arriveLabel.Color = NextStationWindow.GetArrivalColor(stop.arrivalDT, actArr);
+                            departLabel.Color = NextStationWindow.GetDepartColor(stop.departureDT, actDep);
+                        }
+                    }
+                }));
             }
             Tabs.Add(new TabData(Tab.LocomotiveProcedures, Viewer.Catalog.GetString("Procedures"), (cl) =>
             {
@@ -1195,6 +1230,7 @@ namespace Orts.Viewer3D.Popups
             ActivityWorkOrders,
             ActivityEvaluation,
             TimetableBriefing,
+            Timetable,
             LocomotiveProcedures,
         }
 


### PR DESCRIPTION
## Summary
- Preserve complete timetable by storing all station stops
- Show full timetable in F1 help window
- Refactor clock multiplier handling to support time-accelerated activity and timetable definitions

## Testing
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `dotnet build Source/ORTS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e2f53b70832489dd60ca07f75cd4