### PR TITLE
Add timetable tab for timetable mode

### DIFF
--- a/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
+++ b/Source/RunActivity/Viewer3D/Popups/HelpWindow.cs
@@ -564,6 +564,48 @@ namespace Orts.Viewer3D.Popups
                     var textFlow = new TextFlow(scrollbox.RemainingWidth, briefing);
                     scrollbox.Add(textFlow);
                 }));
+
+                Tabs.Add(new TabData(Tab.TimetableTimetable, Viewer.Catalog.GetString("Timetable"), (cl) =>
+                {
+                    var colWidth = (cl.RemainingWidth - cl.TextHeight) / 7;
+                    {
+                        var line = cl.AddLayoutHorizontalLineOfText();
+                        line.Add(new Label(colWidth * 3, line.RemainingHeight, Viewer.Catalog.GetString("Station")));
+                        line.Add(new Label(colWidth, line.RemainingHeight, Viewer.Catalog.GetString("Arrive"), LabelAlignment.Center));
+                        line.Add(new Label(colWidth, line.RemainingHeight, Viewer.Catalog.GetString("Actual"), LabelAlignment.Center));
+                        line.Add(new Label(colWidth, line.RemainingHeight, Viewer.Catalog.GetString("Depart"), LabelAlignment.Center));
+                        line.Add(new Label(colWidth, line.RemainingHeight, Viewer.Catalog.GetString("Actual"), LabelAlignment.Center));
+                    }
+                    cl.AddHorizontalSeparator();
+                    var scrollbox = cl.AddLayoutScrollboxVertical(cl.RemainingWidth);
+                    var tTTrain = owner.Viewer.SelectedTrain as Orts.Simulation.Timetables.TTTrain;
+                    if (tTTrain != null)
+                    {
+                        var stops = new List<Train.StationStop>();
+                        if (tTTrain.PreviousStop != null)
+                            stops.Add(tTTrain.PreviousStop);
+                        if (tTTrain.StationStops != null)
+                            stops.AddRange(tTTrain.StationStops);
+                        foreach (var stop in stops)
+                        {
+                            Label arrive, depart;
+                            var line = scrollbox.AddLayoutHorizontalLineOfText();
+                            line.Add(new Label(colWidth * 3, line.RemainingHeight, stop.PlatformItem?.Name ?? ""));
+                            line.Add(new Label(colWidth, line.RemainingHeight, stop.arrivalDT.ToString("HH:mm:ss"), LabelAlignment.Center));
+                            DateTime? actArr = stop.ActualArrival >= 0 ? new DateTime((long)(Math.Pow(10, 7) * stop.ActualArrival)) : (DateTime?)null;
+                            line.Add(arrive = new Label(colWidth, line.RemainingHeight,
+                                actArr.HasValue ? actArr.Value.ToString("HH:mm:ss") : stop.Passed ? Viewer.Catalog.GetString("(missed)") : "",
+                                LabelAlignment.Center));
+                            line.Add(new Label(colWidth, line.RemainingHeight, stop.departureDT.ToString("HH:mm:ss"), LabelAlignment.Center));
+                            DateTime? actDep = stop.ActualDepart >= 0 ? new DateTime((long)(Math.Pow(10, 7) * stop.ActualDepart)) : (DateTime?)null;
+                            line.Add(depart = new Label(colWidth, line.RemainingHeight,
+                                actDep.HasValue ? actDep.Value.ToString("HH:mm:ss") : stop.Passed ? Viewer.Catalog.GetString("(missed)") : "",
+                                LabelAlignment.Center));
+                            arrive.Color = NextStationWindow.GetArrivalColor(stop.arrivalDT, actArr);
+                            depart.Color = NextStationWindow.GetDepartColor(stop.departureDT, actDep);
+                        }
+                    }
+                }));
             }
             Tabs.Add(new TabData(Tab.LocomotiveProcedures, Viewer.Catalog.GetString("Procedures"), (cl) =>
             {
@@ -1195,6 +1237,7 @@ namespace Orts.Viewer3D.Popups
             ActivityWorkOrders,
             ActivityEvaluation,
             TimetableBriefing,
+            TimetableTimetable,
             LocomotiveProcedures,
         }
 


### PR DESCRIPTION
## Summary
- extend help window tabs with timetable tab for timetable-mode trains
- enumerate new TimetableTimetable tab

## Testing
- `msbuild Source/ORTS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e2f132a08324857c68ff67770573