### PR TITLE
Remove unused intersection guard

### DIFF
--- a/Source/Orts.Formats.OR/DrawUtility.cs
+++ b/Source/Orts.Formats.OR/DrawUtility.cs
@@ -159,8 +159,6 @@ namespace Orts.Formats.OR
             PointF intersection;
             if (track.isCurved)
             {
-                if ((int)(track.startPoint.X) == 45892)
-                    intersection = PointF.Empty;
                 intersection = DrawUtility.FindCurveIntersection(segArea, track);
             }
             else


### PR DESCRIPTION
## Summary
- Remove leftover magic constant check in DrawUtility's `FindIntersection`

## Testing
- `dotnet build Source/Orts.Formats.OR/Orts.Formats.OR.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c26b2b49688324bfa85b76119aacdd